### PR TITLE
feature: improve stack serialization

### DIFF
--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -89,12 +89,15 @@ ApplicationStarterCommandLineHandler >> dumpStackAndReport: exception [
 					Smalltalk tools debugger
 						openOn:
 							(Processor activeProcess
-								newDebugSessionNamed: 'External stack'
+								newDebugSessionNamed:
+									('Materialized stack: <1s>' expandMacrosWith: materialization root receiver description)
 								startedAt: materialization root)
 						withFullView: true ].
 
 			binaryMemoryStream := WriteStream on: (ByteArray new: 100).
-			serializer serialize: thisContext on: binaryMemoryStream.
+			serializer
+				serialize: (thisContext contextStack detect: [ :context | context receiver = exception ])
+				on: binaryMemoryStream.
 			self defaultStackDumpFile
 				writeStreamDo: [ :stream | 
 					stream binary.


### PR DESCRIPTION
- Adds a better title to the serialized stack: _Materialized stack: <exception description>_
- Skips the top context of stack between the handling and the original error.