### PR TITLE
Avoid dumping stack to memory, stream directly to file instead

### DIFF
--- a/source/Application-Starter-Pharo6/MemoryHandle.extension.st
+++ b/source/Application-Starter-Pharo6/MemoryHandle.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #MemoryHandle }
+
+{ #category : #'*Application-Starter-Pharo6' }
+MemoryHandle >> writeStream [
+
+	"Return a writestream on my contents.
+	Using myself as target collection allows to share the internal bytearray between multiple streams."
+
+	^ RWBinaryOrTextStream on: self from: 1 to: entry fileSize
+]

--- a/source/Application-Starter-Pharo7/ZnBufferedWriteStream.extension.st
+++ b/source/Application-Starter-Pharo7/ZnBufferedWriteStream.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #ZnBufferedWriteStream }
+
+{ #category : #'*Application-Starter-Pharo7' }
+ZnBufferedWriteStream >> nextBytesPutAll: aCollection [
+
+	"Append the bytes of aCollection to the sequence of bytes accessible 
+	by the receiver. Answer aCollection."
+
+	^ self nextPutAll: aCollection
+]

--- a/source/Application-Starter/ErrorStackSerializer.class.st
+++ b/source/Application-Starter/ErrorStackSerializer.class.st
@@ -18,12 +18,10 @@ ErrorStackSerializer class >> openDebuggerOn: anExecutionStack [
 { #category : #utilities }
 ErrorStackSerializer class >> serializeStackOf: aSignal to: aFile [
 
-	| binaryMemoryStream stackToDump |
+	| stackToDump |
 
-	binaryMemoryStream := WriteStream on: ( ByteArray new: 100 ).
 	stackToDump := thisContext contextStack detect: [ :context | context receiver = aSignal ].
-	self serializer serialize: stackToDump on: binaryMemoryStream.
-	aFile binaryWriteStreamDo: [ :stream | stream nextPutAll: binaryMemoryStream contents ]
+	aFile binaryWriteStreamDo: [ :stream | self serializer serialize: stackToDump on: stream ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
This should fix the problems with the memory filesystem used for tests, which has weird behavior, and avoid the hack of dumping onto a ByteArray and then to file.

Not dumping to a ByteArray should improve performance and memory usage.

The change differs between Pharo 6 and 7 because of the way streams and files are handled.

A PR to pharo may be required
