### PR TITLE
Remove sudo: false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: smalltalk
-sudo: false
 os:
 - linux
 smalltalk:


### PR DESCRIPTION
https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure
> Container-based infrastructure has been fully deprecated. Please remove any sudo: false keys in your .travis.yml file to use the fully-virtualized Linux infrastructure.