### PR TITLE
Ease of use

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -7,13 +7,14 @@ Should the worst happend and an unexpected error raises, ApplicationStarter prov
 ## How to debug it
 
 You need:
+
 - An image with your code loaded.
-    - _If you can use the same image where the error generated better, otherwise, you need to have all the code loaded, otherwise fuel will not be able to deserialize the context_.
+  - _If you can use the same image where the error generated better, otherwise, you need to have all the code loaded, otherwise fuel will not be able to deserialize the context_.
 - The dump file **the-file.fuel** in this example.
 - Materialize the fuel file by any of the following methods:
-    - By dragging it to the image
-    - Opening it from the file browser
-    - Execute the following code on a Playground
+  - By dragging it to the image
+  - Opening it from the file browser
+  - Execute the following code on a Playground
 
 ```smalltalk
 | session |

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -3,13 +3,15 @@
 ## Basic Installation
 
 You can load **ApplicationStarter** evaluating:
+
 ```smalltalk
 Metacello new
-	baseline: 'ApplicationStarter';
-	repository: 'github://ba-st/ApplicationStarter:master/source';
-	load.
+ baseline: 'ApplicationStarter';
+ repository: 'github://ba-st/ApplicationStarter:master/source';
+ load.
 ```
->  Change `master` to some released version if you want a pinned version
+
+> Change `master` to some released version if you want a pinned version
 
 ## Using as dependency
 
@@ -18,21 +20,22 @@ In order to include **ApplicationStarter** as part of your project, you should r
 ```smalltalk
 setUpDependencies: spec
 
-	spec
-		baseline: 'ApplicationStarter'
-			with: [ spec
-				repository: 'github://ba-st/ApplicationStarter:v{XX}/source';
-				loads: #('Deployment') ];
-		import: 'ApplicationStarter'.
+ spec
+  baseline: 'ApplicationStarter'
+   with: [ spec
+    repository: 'github://ba-st/ApplicationStarter:v{XX}/source';
+    loads: #('Deployment') ];
+  import: 'ApplicationStarter'.
 ```
+
 > Replace `{XX}` with the version you want to depend on
 
 ```smalltalk
 baseline: spec
 
-	<baseline>
-	spec
-		for: #common
-		do: [ self setUpDependencies: spec.
-			spec package: 'My-Package' with: [ spec requires: #('ApplicationStarter') ] ]
+ <baseline>
+ spec
+  for: #common
+  do: [ self setUpDependencies: spec.
+   spec package: 'My-Package' with: [ spec requires: #('ApplicationStarter') ] ]
 ```

--- a/source/Application-Starter-Examples/ExampleApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter-Examples/ExampleApplicationStarterCommandLineHandler.class.st
@@ -13,12 +13,32 @@ ExampleApplicationStarterCommandLineHandler class >> commandName [
 	^ 'example'
 ]
 
+{ #category : #'private - defaults' }
+ExampleApplicationStarterCommandLineHandler class >> defaultLogFile [
+
+	"We override this to be able to test it, it's not required to be overriden"
+
+	| timestamp fileName |
+
+	timestamp := DateAndTime current asUTC printString copyFrom: 1 to: 10.
+	fileName := self logPrefix isEmpty
+		ifTrue: [ timestamp ]
+		ifFalse: [ '<1s>-<2s>' expandMacrosWith: self logPrefix with: timestamp ].
+	^ self defaultLogsPath / fileName withExtension: 'log'
+]
+
 { #category : #accessing }
 ExampleApplicationStarterCommandLineHandler class >> description [
 
 	"This method should return a short one-line description of the command"
 
 	^ 'An example command line handler'
+]
+
+{ #category : #'private - accessing' }
+ExampleApplicationStarterCommandLineHandler class >> logPrefix [
+
+	^ 'example'
 ]
 
 { #category : #accessing }
@@ -31,11 +51,13 @@ ExampleApplicationStarterCommandLineHandler >> add [
 ExampleApplicationStarterCommandLineHandler >> basicActivate [
 
 	( self configuration at: 'fail' )
-		ifTrue: [ self exitFailure: 'This was a forced failure, should not dump a stack on runtime, nor log nothing specific' ].
+		ifTrue: [ self
+				exitFailure: 'This was a forced failure, should not dump a stack on runtime, nor log nothing specific'
+			].
 	( self configuration at: 'raise-error' )
 		ifTrue: [ self error: 'This was a forced error, which should dump a stack file on runtime' ].
-	self
-		logInfo: ( 'The sum of <1p> and <2p> is <3p>' expandMacrosWith: self seed with: self add with: self sum ).
+	CurrentLogger value
+		info: ( 'The sum of <1p> and <2p> is <3p>' expandMacrosWith: self seed with: self add with: self sum ).
 	( self configuration at: 'quit' )
 		ifTrue: [ Smalltalk snapshot: false andQuit: true ]
 ]
@@ -50,20 +72,6 @@ ExampleApplicationStarterCommandLineHandler >> configurationDefinition [
 		add: ( OptionalArgument named: 'seed' defaultingTo: 0 convertingWith: #asNumber );
 		add: ( MandatoryArgument named: 'add' convertingWith: [ :arg | arg asNumber ] );
 		asArray
-]
-
-{ #category : #'private - accessing' }
-ExampleApplicationStarterCommandLineHandler >> currentTimeStampString [
-
-	"We override this to be able to test it, it's not required to be overriden"
-
-	^ DateAndTime current asUTC printString copyFrom: 1 to: 10
-]
-
-{ #category : #'private - accessing' }
-ExampleApplicationStarterCommandLineHandler >> logPrefix [
-
-	^ 'example'
 ]
 
 { #category : #accessing }

--- a/source/Application-Starter-Examples/ExampleApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter-Examples/ExampleApplicationStarterCommandLineHandler.class.st
@@ -57,7 +57,7 @@ ExampleApplicationStarterCommandLineHandler >> basicActivate [
 	( self configuration at: 'raise-error' )
 		ifTrue: [ self error: 'This was a forced error, which should dump a stack file on runtime' ].
 	CurrentLogger value
-		info: ( 'The sum of <1p> and <2p> is <3p>' expandMacrosWith: self seed with: self add with: self sum ).
+		logAsInfo: ( 'The sum of <1p> and <2p> is <3p>' expandMacrosWith: self seed with: self add with: self sum ).
 	( self configuration at: 'quit' )
 		ifTrue: [ Smalltalk snapshot: false andQuit: true ]
 ]

--- a/source/Application-Starter-Migration-V1-V2/ApplicationStarterCommandLineHandler.extension.st
+++ b/source/Application-Starter-Migration-V1-V2/ApplicationStarterCommandLineHandler.extension.st
@@ -1,0 +1,67 @@
+Extension { #name : #ApplicationStarterCommandLineHandler }
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> logError: anErrorMessage [
+
+	self
+		deprecated: 'Please use CurrentLogger value error: instead'
+		transformWith: '`@receiver logError: ̀@message' -> '`CurrentLogger value error: `@message'.
+
+	CurrentLogger value error: anErrorMessage
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> logError: anErrorMessage during: aBlock [
+
+	self
+		deprecated: 'Please use CurrentLogger value error:during: instead'
+		transformWith:
+			'`@receiver logError: ̀@message during: ̀@block'
+				-> '`CurrentLogger value error: `@message during: `@block'.
+
+	CurrentLogger value error: anErrorMessage during: aBlock
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> logInfo: aMessage [
+
+	self
+		deprecated: 'Please use CurrentLogger value info: instead'
+		transformWith: '`@receiver logInfo: ̀@message' -> '`CurrentLogger value info: `@message'.
+
+	CurrentLogger value info: aMessage
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
+
+	self
+		deprecated: 'Please use CurrentLogger value info:during: instead'
+		transformWith:
+			'`@receiver logInfo: ̀@message during: ̀@block'
+				-> '`CurrentLogger value info: `@message during: `@block'.
+
+	CurrentLogger value info: anErrorMessage during: aBlock
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage [
+
+	self
+		deprecated: 'Please use CurrentLogger value warning: instead'
+		transformWith: '`@receiver logWarning: ̀@message' -> '`CurrentLogger value warning: `@message'.
+
+	CurrentLogger value warning: anErrorMessage
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage during: aBlock [
+
+	self
+		deprecated: 'Please use CurrentLogger value warning:during: instead'
+		transformWith:
+			'`@receiver logWarning: ̀@message during: ̀@block'
+				-> '`CurrentLogger value warning: `@message during: `@block'.
+
+	CurrentLogger value warning: anErrorMessage during: aBlock
+]

--- a/source/Application-Starter-Migration-V1-V2/ApplicationStarterCommandLineHandler.extension.st
+++ b/source/Application-Starter-Migration-V1-V2/ApplicationStarterCommandLineHandler.extension.st
@@ -62,9 +62,9 @@ ApplicationStarterCommandLineHandler >> logError: anErrorMessage [
 		deprecated: 'Please use CurrentLogger value error: instead'
 		on: '2019-11-15'
 		in: 'v2'
-		transformWith: '`@receiver logError: ̀@message' -> '`CurrentLogger value error: `@message'.
+		transformWith: '`@receiver logError: ̀@message' -> '`CurrentLogger value logAsError: `@message'.
 
-	CurrentLogger value error: anErrorMessage
+	CurrentLogger value logAsError: anErrorMessage
 ]
 
 { #category : #'*Application-Starter-Migration-V1-V2' }
@@ -76,9 +76,9 @@ ApplicationStarterCommandLineHandler >> logError: anErrorMessage during: aBlock 
 		in: 'v2'
 		transformWith:
 			'`@receiver logError: ̀@message during: ̀@block'
-				-> '`CurrentLogger value error: `@message during: `@block'.
+				-> '`CurrentLogger value logAsError: `@message during: `@block'.
 
-	CurrentLogger value error: anErrorMessage during: aBlock
+	CurrentLogger value logAsError: anErrorMessage during: aBlock
 ]
 
 { #category : #'*Application-Starter-Migration-V1-V2' }
@@ -88,9 +88,9 @@ ApplicationStarterCommandLineHandler >> logInfo: aMessage [
 		deprecated: 'Please use CurrentLogger value info: instead'
 		on: '2019-11-15'
 		in: 'v2'
-		transformWith: '`@receiver logInfo: ̀@message' -> '`CurrentLogger value info: `@message'.
+		transformWith: '`@receiver logInfo: ̀@message' -> '`CurrentLogger value logAsInfo: `@message'.
 
-	CurrentLogger value info: aMessage
+	CurrentLogger value logAsInfo: aMessage
 ]
 
 { #category : #'*Application-Starter-Migration-V1-V2' }
@@ -102,9 +102,9 @@ ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
 		in: 'v2'
 		transformWith:
 			'`@receiver logInfo: ̀@message during: ̀@block'
-				-> '`CurrentLogger value info: `@message during: `@block'.
+				-> '`CurrentLogger value logAsInfo: `@message during: `@block'.
 
-	CurrentLogger value info: anErrorMessage during: aBlock
+	CurrentLogger value logAsInfo: anErrorMessage during: aBlock
 ]
 
 { #category : #'*Application-Starter-Migration-V1-V2' }
@@ -125,9 +125,9 @@ ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage [
 		deprecated: 'Please use CurrentLogger value warning: instead'
 		on: '2019-11-15'
 		in: 'v2'
-		transformWith: '`@receiver logWarning: ̀@message' -> '`CurrentLogger value warning: `@message'.
+		transformWith: '`@receiver logWarning: ̀@message' -> '`CurrentLogger value logAsWarning: `@message'.
 
-	CurrentLogger value warning: anErrorMessage
+	CurrentLogger value logAsWarning: anErrorMessage
 ]
 
 { #category : #'*Application-Starter-Migration-V1-V2' }
@@ -139,7 +139,7 @@ ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage during: aBloc
 		in: 'v2'
 		transformWith:
 			'`@receiver logWarning: ̀@message during: ̀@block'
-				-> '`CurrentLogger value warning: `@message during: `@block'.
+				-> '`CurrentLogger value logAsWarning: `@message during: `@block'.
 
-	CurrentLogger value warning: anErrorMessage during: aBlock
+	CurrentLogger value logAsWarning: anErrorMessage during: aBlock
 ]

--- a/source/Application-Starter-Migration-V1-V2/ApplicationStarterCommandLineHandler.extension.st
+++ b/source/Application-Starter-Migration-V1-V2/ApplicationStarterCommandLineHandler.extension.st
@@ -1,10 +1,67 @@
 Extension { #name : #ApplicationStarterCommandLineHandler }
 
 { #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> currentTimeStampString [
+
+	self
+		deprecated: 'Please use the class side method instead'
+		on: '2019-11-15'
+		in: 'v2'
+		transformWith: '`@receiver currentTimeStampString' -> '`@receiver class currentTimeStampString'.
+	^ self class currentTimeStampString
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> defaultLogFile [
+
+	self
+		deprecated: 'Please use the class side method instead'
+		on: '2019-11-15'
+		in: 'v2'
+		transformWith: '`@receiver defaultLogFile' -> '`@receiver class defaultLogFile'.
+	^ self class defaultLogFile
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> defaultLogsPath [
+
+	self
+		deprecated: 'Please use the class side method instead'
+		on: '2019-11-15'
+		in: 'v2'
+		transformWith: '`@receiver defaultLogsPath' -> '`@receiver class defaultLogsPath'.
+	^ self class defaultLogsPath
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> defaultStackDumpFile [
+
+	self
+		deprecated: 'Please use the class side method instead'
+		on: '2019-11-15'
+		in: 'v2'
+		transformWith: '`@receiver defaultStackDumpFile' -> '`@receiver class defaultStackDumpFile'.
+	^ self class defaultStackDumpFile
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> dumpStackAndReport: aSignal [
+
+	self
+		deprecated: 'Please use the class side method instead'
+		on: '2019-11-15'
+		in: 'v2'
+		transformWith: '`@receiver dumpStackAndReport: `@signal' -> '`@receiver class dumpStackAndReport: `@signal'.
+	^ self class dumpStackAndReport: aSignal
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
 ApplicationStarterCommandLineHandler >> logError: anErrorMessage [
 
 	self
 		deprecated: 'Please use CurrentLogger value error: instead'
+		on: '2019-11-15'
+		in: 'v2'
 		transformWith: '`@receiver logError: ̀@message' -> '`CurrentLogger value error: `@message'.
 
 	CurrentLogger value error: anErrorMessage
@@ -15,6 +72,8 @@ ApplicationStarterCommandLineHandler >> logError: anErrorMessage during: aBlock 
 
 	self
 		deprecated: 'Please use CurrentLogger value error:during: instead'
+		on: '2019-11-15'
+		in: 'v2'
 		transformWith:
 			'`@receiver logError: ̀@message during: ̀@block'
 				-> '`CurrentLogger value error: `@message during: `@block'.
@@ -27,6 +86,8 @@ ApplicationStarterCommandLineHandler >> logInfo: aMessage [
 
 	self
 		deprecated: 'Please use CurrentLogger value info: instead'
+		on: '2019-11-15'
+		in: 'v2'
 		transformWith: '`@receiver logInfo: ̀@message' -> '`CurrentLogger value info: `@message'.
 
 	CurrentLogger value info: aMessage
@@ -37,6 +98,8 @@ ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
 
 	self
 		deprecated: 'Please use CurrentLogger value info:during: instead'
+		on: '2019-11-15'
+		in: 'v2'
 		transformWith:
 			'`@receiver logInfo: ̀@message during: ̀@block'
 				-> '`CurrentLogger value info: `@message during: `@block'.
@@ -45,10 +108,23 @@ ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
 ]
 
 { #category : #'*Application-Starter-Migration-V1-V2' }
+ApplicationStarterCommandLineHandler >> logPrefix [
+
+	self
+		deprecated: 'Please use the class side method instead'
+		on: '2019-11-15'
+		in: 'v2'
+		transformWith: '`@receiver logPrefix' -> '`@receiver class logPrefix'.
+	^ self class logPrefix
+]
+
+{ #category : #'*Application-Starter-Migration-V1-V2' }
 ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage [
 
 	self
 		deprecated: 'Please use CurrentLogger value warning: instead'
+		on: '2019-11-15'
+		in: 'v2'
 		transformWith: '`@receiver logWarning: ̀@message' -> '`CurrentLogger value warning: `@message'.
 
 	CurrentLogger value warning: anErrorMessage
@@ -59,6 +135,8 @@ ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage during: aBloc
 
 	self
 		deprecated: 'Please use CurrentLogger value warning:during: instead'
+		on: '2019-11-15'
+		in: 'v2'
 		transformWith:
 			'`@receiver logWarning: ̀@message during: ̀@block'
 				-> '`CurrentLogger value warning: `@message during: `@block'.

--- a/source/Application-Starter-Migration-V1-V2/package.st
+++ b/source/Application-Starter-Migration-V1-V2/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Application-Starter-Migration-V1-V2' }

--- a/source/Application-Starter-Tests/DummyApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter-Tests/DummyApplicationStarterCommandLineHandler.class.st
@@ -5,7 +5,7 @@ Class {
 		'activationBlock'
 	],
 	#classVars : [
-		'memoryLogPasthConfiguredFromTest'
+		'memoryLogPathConfiguredFromTest'
 	],
 	#category : #'Application-Starter-Tests'
 }
@@ -19,13 +19,13 @@ DummyApplicationStarterCommandLineHandler class >> commandName [
 { #category : #'private - accessing' }
 DummyApplicationStarterCommandLineHandler class >> defaultLogsPath [
 
-	^ memoryLogPasthConfiguredFromTest
+	^ memoryLogPathConfiguredFromTest
 ]
 
 { #category : #'private - accessing' }
 DummyApplicationStarterCommandLineHandler class >> defaultLogsPath: aPath [
 
-	memoryLogPasthConfiguredFromTest := aPath
+	memoryLogPathConfiguredFromTest := aPath
 ]
 
 { #category : #accessing }

--- a/source/Application-Starter-Tests/DummyApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter-Tests/DummyApplicationStarterCommandLineHandler.class.st
@@ -2,8 +2,10 @@ Class {
 	#name : #DummyApplicationStarterCommandLineHandler,
 	#superclass : #ApplicationStarterCommandLineHandler,
 	#instVars : [
-		'memoryLogPasthConfiguredFromTest',
 		'activationBlock'
+	],
+	#classVars : [
+		'memoryLogPasthConfiguredFromTest'
 	],
 	#category : #'Application-Starter-Tests'
 }
@@ -14,10 +16,28 @@ DummyApplicationStarterCommandLineHandler class >> commandName [
 	^ 'dummy'
 ]
 
+{ #category : #'private - accessing' }
+DummyApplicationStarterCommandLineHandler class >> defaultLogsPath [
+
+	^ memoryLogPasthConfiguredFromTest
+]
+
+{ #category : #'private - accessing' }
+DummyApplicationStarterCommandLineHandler class >> defaultLogsPath: aPath [
+
+	memoryLogPasthConfiguredFromTest := aPath
+]
+
 { #category : #accessing }
 DummyApplicationStarterCommandLineHandler class >> description [
 
 	^ 'this is a dummy command line handler for tests'
+]
+
+{ #category : #'private - accessing' }
+DummyApplicationStarterCommandLineHandler class >> logPrefix [
+
+	^ 'dummy'
 ]
 
 { #category : #initialization }
@@ -26,7 +46,7 @@ DummyApplicationStarterCommandLineHandler >> activationBlock: aBlock [
 	activationBlock := aBlock
 ]
 
-{ #category : #activation }
+{ #category : #'private - activation' }
 DummyApplicationStarterCommandLineHandler >> basicActivate [
 
 	activationBlock value
@@ -41,29 +61,11 @@ DummyApplicationStarterCommandLineHandler >> configurationDefinition [
 		yourself
 ]
 
-{ #category : #'private - accessing' }
-DummyApplicationStarterCommandLineHandler >> defaultLogsPath [
-
-	^ memoryLogPasthConfiguredFromTest
-]
-
-{ #category : #'private - accessing' }
-DummyApplicationStarterCommandLineHandler >> defaultLogsPath: aPath [
-
-	memoryLogPasthConfiguredFromTest := aPath
-]
-
 { #category : #initialization }
 DummyApplicationStarterCommandLineHandler >> initialize [
 
 	super initialize.
 	self activationBlock: [  ]
-]
-
-{ #category : #'private - accessing' }
-DummyApplicationStarterCommandLineHandler >> logPrefix [
-
-	^ 'dummy'
 ]
 
 { #category : #initialization }

--- a/source/Application-Starter-Tests/DummyApplicationStarterCommandLineHandlerTest.class.st
+++ b/source/Application-Starter-Tests/DummyApplicationStarterCommandLineHandlerTest.class.st
@@ -23,18 +23,11 @@ DummyApplicationStarterCommandLineHandlerTest >> assert: anOutputStream matches:
 ]
 
 { #category : #running }
-DummyApplicationStarterCommandLineHandlerTest >> configureForTest: handler [
-
-	handler stdout: fakeStdout writeStream.
-	handler stderr: fakeStderr writeStream.
-	handler defaultLogsPath: memoryFileSystem / 'logs'
-]
-
-{ #category : #running }
 DummyApplicationStarterCommandLineHandlerTest >> setUp [
 
 	super setUp.
 	memoryFileSystem := FileSystem memory.
+	DummyApplicationStarterCommandLineHandler defaultLogsPath: memoryFileSystem / 'logs'.
 	fakeStdout := memoryFileSystem / 'stdout'.
 	fakeStderr := memoryFileSystem / 'stderr'.
 	currentLogFileName := Smalltalk logFileName.
@@ -51,143 +44,142 @@ DummyApplicationStarterCommandLineHandlerTest >> tearDown [
 { #category : #tests }
 DummyApplicationStarterCommandLineHandlerTest >> testActivation [
 
-	| arguments handler |
+	CurrentLogger
+		value: ( LeveledLogger outputTo: fakeStdout writeStream errorsTo: fakeStderr writeStream )
+		during: [ | arguments handler |
 
-	arguments := CommandLineArguments
-		withArguments: {'start-service' . '--debug-mode' . '--optional=used-optional' . '--mandatory=something'}.
-	handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
-	handler activationBlock: [ activated := true ].
-	self configureForTest: handler.
-	self deny: activated.
-	self assert: fakeStdout contents isEmpty.
-	self assert: fakeStderr contents isEmpty.
-	self shouldnt: [ handler activate ] raise: Exit.
-	self assert: activated.
-	self
-		assert:
-			( ( '<1s>/<2s>-*Z.log' expandMacrosWith: handler defaultLogsPath pathString with: handler logPrefix )
-				match: Smalltalk logFileName ).
-	self assert: fakeStderr contents isEmpty.
-	self deny: fakeStdout contents isEmpty.
-	self
-		assert: fakeStdout
-		matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''used-optional'''}.
-	self assert: ( handler configuration at: #optional ) equals: 'used-optional'.
-	self assert: ( handler configuration at: #mandatory ) equals: 'something'
+			arguments := CommandLineArguments
+				withArguments: {'start-service' . '--debug-mode' . '--optional=used-optional' . '--mandatory=something'}.
+			handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
+			handler activationBlock: [ activated := true ].
+			self deny: activated.
+			self assert: fakeStdout contents isEmpty.
+			self assert: fakeStderr contents isEmpty.
+			self shouldnt: [ handler activate ] raise: Exit.
+			self assert: activated.
+			self assert: ( '/logs/dummy-*.log' match: Smalltalk logFileName ).
+			self assert: fakeStderr contents isEmpty.
+			self deny: fakeStdout contents isEmpty.
+			self
+				assert: fakeStdout
+				matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''used-optional'''}.
+			self assert: ( handler configuration at: #optional ) equals: 'used-optional'.
+			self assert: ( handler configuration at: #mandatory ) equals: 'something'
+			]
 ]
 
 { #category : #tests }
 DummyApplicationStarterCommandLineHandlerTest >> testActivationWithErrorInDebugMode [
 
-	| arguments handler |
+	CurrentLogger
+		value: ( LeveledLogger outputTo: fakeStdout writeStream errorsTo: fakeStderr writeStream )
+		during: [ | arguments handler |
 
-	arguments := CommandLineArguments
-		withArguments: {'start-service' . '--debug-mode' . '--optional=used-optional' . '--mandatory=something'}.
-	handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
-	handler
-		activationBlock: [ activated := true.
-			ZeroDivide signal
-			].
-	self configureForTest: handler.
-	self deny: activated.
-	self assert: fakeStdout contents isEmpty.
-	self assert: fakeStderr contents isEmpty.
-	self should: [ handler activate ] raise: ZeroDivide.
-	self assert: activated.
-	self
-		assert:
-			( ( '<1s>/<2s>-*Z.log' expandMacrosWith: handler defaultLogsPath pathString with: handler logPrefix )
-				match: Smalltalk logFileName ).
-	self assert: fakeStderr contents isEmpty.
-	self deny: fakeStdout contents isEmpty.
-	self
-		assert: fakeStdout
-		matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''used-optional'''}.
-	self assert: ( handler configuration at: #optional ) equals: 'used-optional'.
-	self assert: ( handler configuration at: #mandatory ) equals: 'something'
+			arguments := CommandLineArguments
+				withArguments: {'start-service' . '--debug-mode' . '--optional=used-optional' . '--mandatory=something'}.
+			handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
+			handler
+				activationBlock: [ activated := true.
+					ZeroDivide signal
+					].
+
+			self deny: activated.
+			self assert: fakeStdout contents isEmpty.
+			self assert: fakeStderr contents isEmpty.
+			self should: [ handler activate ] raise: ZeroDivide.
+			self assert: activated.
+			self assert: ( '/logs/dummy-*.log' match: Smalltalk logFileName ).
+			self assert: fakeStderr contents isEmpty.
+			self deny: fakeStdout contents isEmpty.
+			self
+				assert: fakeStdout
+				matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''used-optional'''}.
+			self assert: ( handler configuration at: #optional ) equals: 'used-optional'.
+			self assert: ( handler configuration at: #mandatory ) equals: 'something'
+			]
 ]
 
 { #category : #tests }
 DummyApplicationStarterCommandLineHandlerTest >> testActivationWithErrorWithoutDebugMode [
 
-	| arguments handler |
+	CurrentLogger
+		value: ( LeveledLogger outputTo: fakeStdout writeStream errorsTo: fakeStderr writeStream )
+		during: [ | arguments handler |
 
-	arguments := CommandLineArguments
-		withArguments: {'start-service' . '--optional=used-optional' . '--mandatory=something'}.
-	handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
-	handler
-		activationBlock: [ activated := true.
-			ZeroDivide signal: 'Division by Zero'
-			].
-	self configureForTest: handler.
-	self deny: activated.
-	self assert: fakeStdout contents isEmpty.
-	self assert: fakeStderr contents isEmpty.
-	self should: [ handler activate ] raise: Exit.
-	self assert: activated.
-	self
-		assert:
-			( ( '<1s>/<2s>-*Z.log' expandMacrosWith: handler defaultLogsPath pathString with: handler logPrefix )
-				match: Smalltalk logFileName ).
-	self
-		assert: fakeStderr
-		matches:
-			{'[*] [ERROR] Dumping Stack Due to Unexpected Error: Division by Zero'.
-			'[*] [ERROR] Dumping Stack Due to Unexpected Error: Division by Zero... [OK]'}.
-	self
-		assert: fakeStdout
-		matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''used-optional'''}.
-	self assert: ( handler configuration at: #optional ) equals: 'used-optional'.
-	self assert: ( handler configuration at: #mandatory ) equals: 'something'.
-	self
-		assert:
-			( handler defaultLogsPath childNames
-				anySatisfy: [ :fileName | ( '<1s>-*Z.fuel' expandMacrosWith: handler logPrefix ) match: fileName ] )
+			arguments := CommandLineArguments
+				withArguments: {'start-service' . '--optional=used-optional' . '--mandatory=something'}.
+			handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
+			handler
+				activationBlock: [ activated := true.
+					ZeroDivide signal: 'Division by Zero'
+					].
+			self deny: activated.
+			self assert: fakeStdout contents isEmpty.
+			self assert: fakeStderr contents isEmpty.
+			self should: [ handler activate ] raise: Exit.
+			self assert: activated.
+			self assert: ( '/logs/dummy-*.log' match: Smalltalk logFileName ).
+			self
+				assert: fakeStderr
+				matches:
+					{'[*] [ERROR] Dumping Stack Due to Unexpected Error: Division by Zero'.
+					'[*] [ERROR] Dumping Stack Due to Unexpected Error: Division by Zero... [OK]'}.
+			self
+				assert: fakeStdout
+				matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''used-optional'''}.
+			self assert: ( handler configuration at: #optional ) equals: 'used-optional'.
+			self assert: ( handler configuration at: #mandatory ) equals: 'something'.
+			self
+				assert:
+					( ( memoryFileSystem / 'logs' ) childNames
+						anySatisfy: [ :fileName | 'dummy-*.fuel' match: fileName ] )
+			]
 ]
 
 { #category : #tests }
 DummyApplicationStarterCommandLineHandlerTest >> testActivationWithoutMandatoryArguments [
 
-	| arguments handler |
+	CurrentLogger
+		value: ( LeveledLogger outputTo: fakeStdout writeStream errorsTo: fakeStderr writeStream )
+		during: [ | arguments handler |
 
-	arguments := CommandLineArguments withArguments: {'start-service' . '--optional=used-optional'}.
-	handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
-	handler activationBlock: [ activated := true ].
-	self configureForTest: handler.
-	self deny: activated.
-	self assert: fakeStdout contents isEmpty.
-	self assert: fakeStderr contents isEmpty.
-	self should: [ handler activate ] raise: Exit.
-	self assert: fakeStdout contents isEmpty.
-	self
-		assert: fakeStderr
-		matches: {'[*] [ERROR] mandatory option not provided. You must provide one.'}
+			arguments := CommandLineArguments withArguments: {'start-service' . '--optional=used-optional'}.
+			handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
+			handler activationBlock: [ activated := true ].
+			self deny: activated.
+			self assert: fakeStdout contents isEmpty.
+			self assert: fakeStderr contents isEmpty.
+			self should: [ handler activate ] raise: Exit.
+			self assert: fakeStdout contents isEmpty.
+			self
+				assert: fakeStderr
+				matches: {'[*] [ERROR] mandatory option not provided. You must provide one.'}
+			]
 ]
 
 { #category : #tests }
 DummyApplicationStarterCommandLineHandlerTest >> testActivationWithoutOptionalArguments [
 
-	| arguments handler |
+	CurrentLogger
+		value: ( LeveledLogger outputTo: fakeStdout writeStream errorsTo: fakeStderr writeStream )
+		during: [ | arguments handler |
 
-	arguments := CommandLineArguments withArguments: {'start-service' . '--mandatory=something'}.
-	handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
-	handler activationBlock: [ activated := true ].
-	self configureForTest: handler.
-	self deny: activated.
-	self assert: fakeStdout contents isEmpty.
-	self assert: fakeStderr contents isEmpty.
-	self shouldnt: [ handler activate ] raise: Exit.
-	self assert: activated.
-	self
-		assert:
-			( ( '<1s>/<2s>-*Z.log' expandMacrosWith: handler defaultLogsPath pathString with: handler logPrefix )
-				match: Smalltalk logFileName ).
-	self
-		assert: fakeStderr
-		matches: {'[*] [WARNING] optional option not provided. Defaulting to ''unused-optional'''}.
-	self
-		assert: fakeStdout
-		matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''unused-optional'''}.
-	self assert: ( handler configuration at: #optional ) equals: 'unused-optional'.
-	self assert: ( handler configuration at: #mandatory ) equals: 'something'
+			arguments := CommandLineArguments withArguments: {'start-service' . '--mandatory=something'}.
+			handler := DummyApplicationStarterCommandLineHandler new commandLine: arguments.
+			handler activationBlock: [ activated := true ].
+			self deny: activated.
+			self assert: fakeStdout contents isEmpty.
+			self assert: fakeStderr contents isEmpty.
+			self shouldnt: [ handler activate ] raise: Exit.
+			self assert: activated.
+			self assert: ( '/logs/dummy-*.log' match: Smalltalk logFileName ).
+			self
+				assert: fakeStderr
+				matches: {'[*] [WARNING] optional option not provided. Defaulting to ''unused-optional'''}.
+			self
+				assert: fakeStdout
+				matches: {'[*] [INFO] mandatory: ''something''' . '[*] [INFO] optional: ''unused-optional'''}.
+			self assert: ( handler configuration at: #optional ) equals: 'unused-optional'.
+			self assert: ( handler configuration at: #mandatory ) equals: 'something'
+			]
 ]

--- a/source/Application-Starter-Tests/ExampleApplicationStarterCommandLineHandlerTest.class.st
+++ b/source/Application-Starter-Tests/ExampleApplicationStarterCommandLineHandlerTest.class.st
@@ -21,7 +21,7 @@ ExampleApplicationStarterCommandLineHandlerTest >> setUp [
 ExampleApplicationStarterCommandLineHandlerTest >> tearDown [
 
 	Smalltalk logFileName: currentLogFileName.
-	ExampleApplicationStarterCommandLineHandler new defaultStackDumpFile ensureDelete.
+	ExampleApplicationStarterCommandLineHandler defaultStackDumpFile ensureDelete.
 	super tearDown
 ]
 
@@ -46,7 +46,7 @@ ExampleApplicationStarterCommandLineHandlerTest >> testActivationWithFail [
 	arguments := CommandLineArguments withArguments: {'example' . '--seed=1' . '--add=5' . '--fail'}.
 	handler := ExampleApplicationStarterCommandLineHandler new commandLine: arguments.
 	self should: [ handler activate ] raise: Exit.
-	self deny: handler defaultStackDumpFile exists
+	self deny: handler class defaultStackDumpFile exists
 ]
 
 { #category : #tests }
@@ -58,5 +58,5 @@ ExampleApplicationStarterCommandLineHandlerTest >> testActivationWithSignalError
 		withArguments: {'example' . '--seed=1' . '--add=5' . '--raise-error'}.
 	handler := ExampleApplicationStarterCommandLineHandler commandLine: arguments.
 	self should: [ handler activate ] raise: Exit.
-	self assert: handler defaultStackDumpFile exists
+	self assert: handler class defaultStackDumpFile exists
 ]

--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -65,7 +65,7 @@ ApplicationStarterCommandLineHandler class >> description [
 ApplicationStarterCommandLineHandler class >> dumpStackAndReport: aSignal [
 
 	^ CurrentLogger value
-		error: ( 'Dumping Stack Due to Unexpected Error: <1s>' expandMacrosWith: aSignal messageText )
+		logAsError: ( 'Dumping Stack Due to Unexpected Error: <1s>' expandMacrosWith: aSignal messageText )
 		during: [ ErrorStackSerializer serializeStackOf: aSignal to: self defaultStackDumpFile ]
 ]
 
@@ -143,7 +143,7 @@ ApplicationStarterCommandLineHandler >> exceptionsToHandle [
 ApplicationStarterCommandLineHandler >> exitFailure: aMessage [
 
 	self isDebugModeEnabled
-		ifTrue: [ CurrentLogger value error: aMessage ]
+		ifTrue: [ CurrentLogger value logAsError: aMessage ]
 		ifFalse: [ super exitFailure: aMessage ]
 ]
 
@@ -163,7 +163,7 @@ ApplicationStarterCommandLineHandler >> logConfiguration [
 	configuration keys sorted
 		do: [ :configurationKey | 
 			CurrentLogger value
-				info:
+				logAsInfo:
 					( '<1s>: <2p>'
 						expandMacrosWith: configurationKey asString
 						with: ( configuration at: configurationKey ) )

--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -49,6 +49,8 @@ ApplicationStarterCommandLineHandler >> activate [
 { #category : #'private - activation' }
 ApplicationStarterCommandLineHandler >> basicActivate [
 
+	"Here you should define the code to start up your application, all the configuration passed by command line can be accessed on the `self configuration` dictionary."
+
 	self subclassResponsibility
 ]
 
@@ -69,6 +71,9 @@ ApplicationStarterCommandLineHandler >> configuration [
 
 { #category : #'private - accessing' }
 ApplicationStarterCommandLineHandler >> configurationDefinition [
+
+	"A collection of the arguments for this handler, wich can be MandatoryArgument, OptionalArgument or FlagArgument.
+	Answer #() if you don't have arguments, but in that case you probably do not need to use this handler :)"
 
 	self subclassResponsibility 
 ]
@@ -208,6 +213,7 @@ ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
 { #category : #'private - accessing' }
 ApplicationStarterCommandLineHandler >> logPrefix [
 
+	"A prefix for the log files, can be an empty string"
 	self subclassResponsibility
 ]
 

--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -166,6 +166,42 @@ ApplicationStarterCommandLineHandler >> logConfiguration [
 			]
 ]
 
+{ #category : #'private - logging' }
+ApplicationStarterCommandLineHandler >> logError: anErrorMessage [
+
+	CurrentLogger value error: anErrorMessage
+]
+
+{ #category : #'private - logging' }
+ApplicationStarterCommandLineHandler >> logError: anErrorMessage during: aBlock [
+
+	CurrentLogger value error: anErrorMessage during: aBlock
+]
+
+{ #category : #'private - logging' }
+ApplicationStarterCommandLineHandler >> logInfo: aMessage [
+
+	CurrentLogger value info: aMessage
+]
+
+{ #category : #'private - logging' }
+ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
+
+	CurrentLogger value info: anErrorMessage during: aBlock
+]
+
+{ #category : #'private - logging' }
+ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage [
+
+	CurrentLogger value warning: anErrorMessage
+]
+
+{ #category : #'private - logging' }
+ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage during: aBlock [
+
+	CurrentLogger value warning: anErrorMessage during: aBlock
+]
+
 { #category : #activation }
 ApplicationStarterCommandLineHandler >> suspendUiIfRequired [
 

--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -166,42 +166,6 @@ ApplicationStarterCommandLineHandler >> logConfiguration [
 			]
 ]
 
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logError: anErrorMessage [
-
-	CurrentLogger value error: anErrorMessage
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logError: anErrorMessage during: aBlock [
-
-	CurrentLogger value error: anErrorMessage during: aBlock
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logInfo: aMessage [
-
-	CurrentLogger value info: aMessage
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
-
-	CurrentLogger value info: anErrorMessage during: aBlock
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage [
-
-	CurrentLogger value warning: anErrorMessage
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage during: aBlock [
-
-	CurrentLogger value warning: anErrorMessage during: aBlock
-]
-
 { #category : #activation }
 ApplicationStarterCommandLineHandler >> suspendUiIfRequired [
 

--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -16,6 +16,39 @@ ApplicationStarterCommandLineHandler class >> commandName [
 	self subclassResponsibility
 ]
 
+{ #category : #'private - defaults' }
+ApplicationStarterCommandLineHandler class >> defaultLogFile [
+
+	| timestamp fileName |
+
+	timestamp := ( DateAndTime current asUTC printString copyWithoutAll: ':' )
+		copyReplaceAll: '+0000'
+		with: 'Z'.
+	fileName := self logPrefix isEmpty
+		ifTrue: [ timestamp ]
+		ifFalse: [ '<1s>-<2s>' expandMacrosWith: self logPrefix with: timestamp ].
+	^ self defaultLogsPath / fileName withExtension: 'log'
+]
+
+{ #category : #'private - defaults' }
+ApplicationStarterCommandLineHandler class >> defaultLogsPath [
+
+	"Sorry for this, but pharo is not consistent across versions with the concept of working directory.
+	Bn old versions it was considered that the working directory is that of the image, which is incorrect.
+	-jmaestri"
+
+	^ ( OSEnvironment current
+		at: 'PWD'
+		ifPresent: #asFileReference
+		ifAbsent: [ FileLocator workingDirectory ] ) / 'logs'
+]
+
+{ #category : #'private - defaults' }
+ApplicationStarterCommandLineHandler class >> defaultStackDumpFile [
+
+	^ self defaultLogFile withExtension: 'fuel'
+]
+
 { #category : #accessing }
 ApplicationStarterCommandLineHandler class >> description [
 
@@ -24,23 +57,39 @@ ApplicationStarterCommandLineHandler class >> description [
 	self subclassResponsibility
 ]
 
+{ #category : #'private - logging' }
+ApplicationStarterCommandLineHandler class >> dumpStackAndReport: aSignal [
+
+	^ CurrentLogger value
+		error: ( 'Dumping Stack Due to Unexpected Error: <1s>' expandMacrosWith: aSignal messageText )
+		during: [ ErrorStackSerializer serializeStackOf: aSignal to: self defaultStackDumpFile ]
+]
+
 { #category : #accessing }
 ApplicationStarterCommandLineHandler class >> isAbstract [
 
 	^ self = ApplicationStarterCommandLineHandler
 ]
 
+{ #category : #'private - accessing' }
+ApplicationStarterCommandLineHandler class >> logPrefix [
+
+	"A prefix for the log files, can be an empty string"
+
+	self subclassResponsibility
+]
+
 { #category : #activation }
 ApplicationStarterCommandLineHandler >> activate [
 
-	self defaultLogsPath ensureCreateDirectory.
-	Smalltalk logFileName: self defaultLogFile pathString.
+	self class defaultLogsPath ensureCreateDirectory.
+	Smalltalk logFileName: self class defaultLogFile pathString.
 	[ self logConfiguration.
 	self basicActivate
 	]
 		on: self exceptionsToHandle
 		do: [ :signal | 
-			self dumpStackAndReport: signal.
+			self class dumpStackAndReport: signal.
 			self exitFailure
 			].
 	self suspendUiIfRequired
@@ -75,50 +124,7 @@ ApplicationStarterCommandLineHandler >> configurationDefinition [
 	"A collection of the arguments for this handler, wich can be MandatoryArgument, OptionalArgument or FlagArgument.
 	Answer #() if you don't have arguments, but in that case you probably do not need to use this handler :)"
 
-	self subclassResponsibility 
-]
-
-{ #category : #'private - accessing' }
-ApplicationStarterCommandLineHandler >> currentTimeStampString [
-
-	^ ( DateAndTime current asUTC printString copyReplaceAll: '+00:00' with: 'Z' )
-		copyReplaceAll: ':'
-		with: ''
-]
-
-{ #category : #'private - defaults' }
-ApplicationStarterCommandLineHandler >> defaultLogFile [
-
-	^ self defaultLogsPath
-		/ ( '<1s>-<2s>.log' expandMacrosWith: self logPrefix with: self currentTimeStampString )
-]
-
-{ #category : #'private - defaults' }
-ApplicationStarterCommandLineHandler >> defaultLogsPath [
-
-	"Sorry for this, but pharo is not consistent across versions with the concept of working directory.
-	Bn old versions it was considered that the working directory is that of the image, which is incorrect.
-	-jmaestri"
-
-	^ ( OSEnvironment current
-		at: 'PWD'
-		ifPresent: #asFileReference
-		ifAbsent: [ FileLocator workingDirectory ] ) / 'logs'
-]
-
-{ #category : #'private - defaults' }
-ApplicationStarterCommandLineHandler >> defaultStackDumpFile [
-
-	^ self defaultLogsPath
-		/ ( '<1s>-<2s>.fuel' expandMacrosWith: self logPrefix with: self currentTimeStampString )
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> dumpStackAndReport: aSignal [
-
-	^ self
-		logError: ( 'Dumping Stack Due to Unexpected Error: <1s>' expandMacrosWith: aSignal messageText )
-		during: [ ErrorStackSerializer serializeStackOf: aSignal to: self defaultStackDumpFile ]
+	self subclassResponsibility
 ]
 
 { #category : #'private - accessing' }
@@ -133,7 +139,7 @@ ApplicationStarterCommandLineHandler >> exceptionsToHandle [
 ApplicationStarterCommandLineHandler >> exitFailure: aMessage [
 
 	self isDebugModeEnabled
-		ifTrue: [ self error: aMessage ]
+		ifTrue: [ CurrentLogger value error: aMessage ]
 		ifFalse: [ super exitFailure: aMessage ]
 ]
 
@@ -144,25 +150,7 @@ ApplicationStarterCommandLineHandler >> isDebugModeEnabled [
 	^ self hasOption: 'debug-mode'
 ]
 
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> log: aMessage to: anOutputStream withLevel: aLogLevel [
-
-	anOutputStream
-		nextPutAll: ( '[<1p>] [<2s>] <3s><n>' expandMacrosWith: DateAndTime current with: aLogLevel with: aMessage );
-		flush
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> log: aMessage to: anOutputStream withLevel: aLogLevel during: aBlock [
-
-	self log: aMessage to: anOutputStream withLevel: aLogLevel.
-	[ aBlock value.
-	self log: aMessage , '... [OK]' to: anOutputStream withLevel: aLogLevel
-	]
-		ifCurtailed: [ self logError: aMessage , '... [FAILED]' ]
-]
-
-{ #category : #'private - logging' }
+{ #category : #'private - activation' }
 ApplicationStarterCommandLineHandler >> logConfiguration [
 
 	| configuration |
@@ -170,67 +158,12 @@ ApplicationStarterCommandLineHandler >> logConfiguration [
 	configuration := self configuration.
 	configuration keys sorted
 		do: [ :configurationKey | 
-			self
-				logInfo:
+			CurrentLogger value
+				info:
 					( '<1s>: <2p>'
 						expandMacrosWith: configurationKey asString
 						with: ( configuration at: configurationKey ) )
 			]
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logError: anErrorMessage [
-
-	self log: anErrorMessage to: self stderr withLevel: 'ERROR'
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logError: anErrorMessage during: aBlock [
-
-	self
-		log: anErrorMessage
-		to: self stderr
-		withLevel: 'ERROR'
-		during: aBlock
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logInfo: aMessage [
-
-	self log: aMessage to: self stdout withLevel: 'INFO'
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logInfo: anErrorMessage during: aBlock [
-
-	self
-		log: anErrorMessage
-		to: self stdout
-		withLevel: 'INFO'
-		during: aBlock
-]
-
-{ #category : #'private - accessing' }
-ApplicationStarterCommandLineHandler >> logPrefix [
-
-	"A prefix for the log files, can be an empty string"
-	self subclassResponsibility
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage [
-
-	self log: anErrorMessage to: self stderr withLevel: 'WARNING'
-]
-
-{ #category : #'private - logging' }
-ApplicationStarterCommandLineHandler >> logWarning: anErrorMessage during: aBlock [
-
-	self
-		log: anErrorMessage
-		to: self stdout
-		withLevel: 'WARNING'
-		during: aBlock
 ]
 
 { #category : #activation }

--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -26,8 +26,8 @@ ApplicationStarterCommandLineHandler class >> defaultLogFile [
 		with: 'Z'.
 	fileName := self logPrefix isEmpty
 		ifTrue: [ timestamp ]
-		ifFalse: [ '<1s>-<2s>' expandMacrosWith: self logPrefix with: timestamp ].
-	^ self defaultLogsPath / fileName withExtension: 'log'
+		ifFalse: [ '<1s>-<2s>.log' expandMacrosWith: self logPrefix with: timestamp ].
+	^ self defaultLogsPath / fileName
 ]
 
 { #category : #'private - defaults' }

--- a/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
+++ b/source/Application-Starter/ApplicationStarterCommandLineHandler.class.st
@@ -17,13 +17,17 @@ ApplicationStarterCommandLineHandler class >> commandName [
 ]
 
 { #category : #'private - defaults' }
+ApplicationStarterCommandLineHandler class >> currentTimeStampString [
+
+	^ ( DateAndTime current asUTC printString copyWithoutAll: ':' ) copyReplaceAll: '+0000' with: 'Z'
+]
+
+{ #category : #'private - defaults' }
 ApplicationStarterCommandLineHandler class >> defaultLogFile [
 
 	| timestamp fileName |
 
-	timestamp := ( DateAndTime current asUTC printString copyWithoutAll: ':' )
-		copyReplaceAll: '+0000'
-		with: 'Z'.
+	timestamp := self currentTimeStampString.
 	fileName := self logPrefix isEmpty
 		ifTrue: [ timestamp ]
 		ifFalse: [ '<1s>-<2s>.log' expandMacrosWith: self logPrefix with: timestamp ].

--- a/source/Application-Starter/CurrentLogger.class.st
+++ b/source/Application-Starter/CurrentLogger.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #CurrentLogger,
+	#superclass : #DynamicVariable,
+	#category : #'Application-Starter'
+}
+
+{ #category : #accessing }
+CurrentLogger >> default [
+
+	^ LeveledLogger default
+]

--- a/source/Application-Starter/ErrorStackSerializer.class.st
+++ b/source/Application-Starter/ErrorStackSerializer.class.st
@@ -7,12 +7,13 @@ Class {
 { #category : #private }
 ErrorStackSerializer class >> openDebuggerOn: anExecutionStack [
 
-	^ Smalltalk tools debugger
+	^ [ Smalltalk tools debugger
 		openOn:
 			( Processor activeProcess
 				newDebugSessionNamed: ( 'Materialized stack: <1s>' expandMacrosWith: anExecutionStack receiver description )
 				startedAt: anExecutionStack )
 		withFullView: true
+	] fork
 ]
 
 { #category : #utilities }

--- a/source/Application-Starter/ErrorStackSerializer.class.st
+++ b/source/Application-Starter/ErrorStackSerializer.class.st
@@ -13,7 +13,7 @@ ErrorStackSerializer class >> openDebuggerOn: anExecutionStack [
 				newDebugSessionNamed: ( 'Materialized stack: <1s>' expandMacrosWith: anExecutionStack receiver description )
 				startedAt: anExecutionStack )
 		withFullView: true
-	] fork
+	] forkNamed: 'Debugging materialized stack'
 ]
 
 { #category : #utilities }

--- a/source/Application-Starter/LeveledLogger.class.st
+++ b/source/Application-Starter/LeveledLogger.class.st
@@ -1,0 +1,98 @@
+Class {
+	#name : #LeveledLogger,
+	#superclass : #Object,
+	#instVars : [
+		'stdout',
+		'stderr'
+	],
+	#classVars : [
+		'Default'
+	],
+	#category : #'Application-Starter'
+}
+
+{ #category : #accessing }
+LeveledLogger class >> default [
+
+	^ Default
+		ifNil: [ Default := self outputTo: VTermOutputDriver stdout errorsTo: VTermOutputDriver stderr ]
+]
+
+{ #category : #accessing }
+LeveledLogger class >> outputTo: anOutputStream errorsTo: anErrorStream [
+
+	^ self new initializeOutputTo: anOutputStream errorsTo: anErrorStream
+]
+
+{ #category : #logging }
+LeveledLogger >> error: anErrorMessage [
+
+	self log: anErrorMessage to: stderr withLevel: 'ERROR'
+]
+
+{ #category : #logging }
+LeveledLogger >> error: anErrorMessage during: aBlock [
+
+	self
+		log: anErrorMessage
+		to: stderr
+		withLevel: 'ERROR'
+		during: aBlock
+]
+
+{ #category : #logging }
+LeveledLogger >> info: aMessage [
+
+	self log: aMessage to: stdout withLevel: 'INFO'
+]
+
+{ #category : #logging }
+LeveledLogger >> info: anErrorMessage during: aBlock [
+
+	self
+		log: anErrorMessage
+		to: stdout
+		withLevel: 'INFO'
+		during: aBlock
+]
+
+{ #category : #initialization }
+LeveledLogger >> initializeOutputTo: anOutputStream errorsTo: anErrorStream [
+
+	stdout := anOutputStream.
+	stderr := anErrorStream
+]
+
+{ #category : #'private - logging' }
+LeveledLogger >> log: aMessage to: anOutputStream withLevel: aLogLevel [
+
+	anOutputStream
+		nextPutAll: ( '[<1p>] [<2s>] <3s><n>' expandMacrosWith: DateAndTime current with: aLogLevel with: aMessage );
+		flush
+]
+
+{ #category : #'private - logging' }
+LeveledLogger >> log: aMessage to: anOutputStream withLevel: aLogLevel during: aBlock [
+
+	self log: aMessage to: anOutputStream withLevel: aLogLevel.
+	[ aBlock value.
+	self log: aMessage , '... [OK]' to: anOutputStream withLevel: aLogLevel
+	]
+		ifCurtailed: [ self error: aMessage , '... [FAILED]' ]
+]
+
+{ #category : #logging }
+LeveledLogger >> warning: anErrorMessage [
+
+	self log: anErrorMessage to: stderr withLevel: 'WARNING'
+]
+
+{ #category : #logging }
+LeveledLogger >> warning: anErrorMessage during: aBlock [
+
+	self
+		log: anErrorMessage
+		to: stdout
+		withLevel: 'WARNING'
+		during: aBlock
+]

--- a/source/Application-Starter/LeveledLogger.class.st
+++ b/source/Application-Starter/LeveledLogger.class.st
@@ -20,54 +20,6 @@ LeveledLogger class >> outputTo: anOutputStream errorsTo: anErrorStream [
 	^ self new initializeOutputTo: anOutputStream errorsTo: anErrorStream
 ]
 
-{ #category : #logging }
-LeveledLogger >> error: anErrorMessage [
-
-	self log: anErrorMessage to: stderr withLevel: 'ERROR'
-]
-
-{ #category : #logging }
-LeveledLogger >> error: anErrorMessage during: aBlock [
-
-	self
-		log: anErrorMessage
-		to: stderr
-		withLevel: 'ERROR'
-		during: aBlock
-]
-
-{ #category : #logging }
-LeveledLogger >> info: aMessage [
-
-	self log: aMessage to: stdout withLevel: 'INFO'
-]
-
-{ #category : #logging }
-LeveledLogger >> info: anErrorMessage during: aBlock [
-
-	self
-		log: anErrorMessage
-		to: stdout
-		withLevel: 'INFO'
-		during: aBlock
-]
-
-{ #category : #logging }
-LeveledLogger >> info: anInformationMessage loggingErrorsDuring: aBlock [
-
-	^ self
-		log: anInformationMessage
-		to: stdout
-		withLevel: 'INFO'
-		during: [ aBlock
-				on: Error
-				do: [ :signal | 
-					self error: signal messageText.
-					signal pass
-					]
-			]
-]
-
 { #category : #initialization }
 LeveledLogger >> initializeOutputTo: anOutputStream errorsTo: anErrorStream [
 
@@ -90,20 +42,68 @@ LeveledLogger >> log: aMessage to: anOutputStream withLevel: aLogLevel during: a
 	[ aBlock value.
 	self log: aMessage , '... [OK]' to: anOutputStream withLevel: aLogLevel
 	]
-		ifCurtailed: [ self error: aMessage , '... [FAILED]' ]
+		ifCurtailed: [ self logAsError: aMessage , '... [FAILED]' ]
 ]
 
 { #category : #logging }
-LeveledLogger >> warning: anErrorMessage [
+LeveledLogger >> logAsError: aMessage [
 
-	self log: anErrorMessage to: stderr withLevel: 'WARNING'
+	self log: aMessage to: stderr withLevel: 'ERROR'
 ]
 
 { #category : #logging }
-LeveledLogger >> warning: anErrorMessage during: aBlock [
+LeveledLogger >> logAsError: aMessage during: aBlock [
 
 	self
-		log: anErrorMessage
+		log: aMessage
+		to: stderr
+		withLevel: 'ERROR'
+		during: aBlock
+]
+
+{ #category : #logging }
+LeveledLogger >> logAsInfo: aMessage [
+
+	self log: aMessage to: stdout withLevel: 'INFO'
+]
+
+{ #category : #logging }
+LeveledLogger >> logAsInfo: aMessage during: aBlock [
+
+	self
+		log: aMessage
+		to: stdout
+		withLevel: 'INFO'
+		during: aBlock
+]
+
+{ #category : #logging }
+LeveledLogger >> logAsInfo: anInformationMessage handlingErrorsDuring: aBlock [
+
+	^ self
+		log: anInformationMessage
+		to: stdout
+		withLevel: 'INFO'
+		during: [ aBlock
+				on: Error
+				do: [ :signal | 
+					self logAsError: signal messageText.
+					signal pass
+					]
+			]
+]
+
+{ #category : #logging }
+LeveledLogger >> logAsWarning: aMessage [
+
+	self log: aMessage to: stderr withLevel: 'WARNING'
+]
+
+{ #category : #logging }
+LeveledLogger >> logAsWarning: aMessage during: aBlock [
+
+	self
+		log: aMessage
 		to: stdout
 		withLevel: 'WARNING'
 		during: aBlock

--- a/source/Application-Starter/LeveledLogger.class.st
+++ b/source/Application-Starter/LeveledLogger.class.st
@@ -52,6 +52,22 @@ LeveledLogger >> info: anErrorMessage during: aBlock [
 		during: aBlock
 ]
 
+{ #category : #logging }
+LeveledLogger >> info: anInformationMessage loggingErrorsDuring: aBlock [
+
+	^ self
+		log: anInformationMessage
+		to: stdout
+		withLevel: 'INFO'
+		during: [ aBlock
+				on: Error
+				do: [ :signal | 
+					self error: signal messageText.
+					signal pass
+					]
+			]
+]
+
 { #category : #initialization }
 LeveledLogger >> initializeOutputTo: anOutputStream errorsTo: anErrorStream [
 

--- a/source/Application-Starter/LeveledLogger.class.st
+++ b/source/Application-Starter/LeveledLogger.class.st
@@ -5,17 +5,13 @@ Class {
 		'stdout',
 		'stderr'
 	],
-	#classVars : [
-		'Default'
-	],
 	#category : #'Application-Starter'
 }
 
 { #category : #accessing }
 LeveledLogger class >> default [
 
-	^ Default
-		ifNil: [ Default := self outputTo: VTermOutputDriver stdout errorsTo: VTermOutputDriver stderr ]
+	^ self outputTo: VTermOutputDriver stdout errorsTo: VTermOutputDriver stderr
 ]
 
 { #category : #accessing }

--- a/source/Application-Starter/MandatoryArgument.class.st
+++ b/source/Application-Starter/MandatoryArgument.class.st
@@ -53,8 +53,8 @@ MandatoryArgument >> argumentFrom: aCommandLineHandler [
 		cull:
 			( aCommandLineHandler
 				optionAt: name
-				ifAbsent: [ aCommandLineHandler
-						logError: ( '<1s> option not provided. You must provide one.' expandMacrosWith: name ).
+				ifAbsent: [ CurrentLogger value
+						error: ( '<1s> option not provided. You must provide one.' expandMacrosWith: name ).
 					aCommandLineHandler exitFailure: ( '<1s> option not present' expandMacrosWith: name )
 					] )
 ]

--- a/source/Application-Starter/MandatoryArgument.class.st
+++ b/source/Application-Starter/MandatoryArgument.class.st
@@ -54,7 +54,7 @@ MandatoryArgument >> argumentFrom: aCommandLineHandler [
 			( aCommandLineHandler
 				optionAt: name
 				ifAbsent: [ CurrentLogger value
-						error: ( '<1s> option not provided. You must provide one.' expandMacrosWith: name ).
+						logAsError: ( '<1s> option not provided. You must provide one.' expandMacrosWith: name ).
 					aCommandLineHandler exitFailure: ( '<1s> option not present' expandMacrosWith: name )
 					] )
 ]

--- a/source/Application-Starter/OptionalArgument.class.st
+++ b/source/Application-Starter/OptionalArgument.class.st
@@ -58,7 +58,7 @@ OptionalArgument >> argumentFrom: aCommandLineHandler [
 			( aCommandLineHandler
 				optionAt: name
 				ifAbsent: [ CurrentLogger value
-						warning: ( '<1s> option not provided. Defaulting to <2p>' expandMacrosWith: name with: default ).
+						logAsWarning: ( '<1s> option not provided. Defaulting to <2p>' expandMacrosWith: name with: default ).
 					default
 					] )
 ]

--- a/source/Application-Starter/OptionalArgument.class.st
+++ b/source/Application-Starter/OptionalArgument.class.st
@@ -57,8 +57,8 @@ OptionalArgument >> argumentFrom: aCommandLineHandler [
 		cull:
 			( aCommandLineHandler
 				optionAt: name
-				ifAbsent: [ aCommandLineHandler
-						logWarning: ( '<1s> option not provided. Defaulting to <2p>' expandMacrosWith: name with: default ).
+				ifAbsent: [ CurrentLogger value
+						warning: ( '<1s> option not provided. Defaulting to <2p>' expandMacrosWith: name with: default ).
 					default
 					] )
 ]


### PR DESCRIPTION
- Don't stop stop the UI Process when closing a revived fuel stack
- Extract logging behavior and move defaults to class side, this should make it easier to log / dump stack files.
- Default files moved to class side to be able to reference them easily.
- Comment subclassResponsibility methods, for clarity

Some of the changes are breaking, this should move to next major version.